### PR TITLE
added gss to benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(FSSS2         "Include fsss2"         OFF)
 option(JCZSOLVE      "Include JCZSolve"      OFF)
 option(JSOLVE        "Include JSolve"        OFF)
 option(KUDOKU        "Include KUDOKU"        OFF)
+option(GSS           "Include GSS"           OFF)
 option(MINISAT       "Include MiniSat"       OFF)
 option(NORVIG        "Include norvig"        OFF)
 option(RUST_SUDOKU   "Include rust_sudoku"   OFF)
@@ -102,6 +103,15 @@ if (KUDOKU)
     add_definitions(-DKUDOKU)
     set(BENCHMARK_SOLVER_SOURCES ${BENCHMARK_SOLVER_SOURCES}
             other/kudoku/kudoku.c)
+endif()
+
+if (GSS)
+    add_definitions(-DGSS)
+	set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -DM32bit -DGCC_POPCNT32")
+    set(BENCHMARK_SOLVER_SOURCES ${BENCHMARK_SOLVER_SOURCES}
+            other/gss/sudoku.c
+            other/gss/sudoku_parser.c
+            other/gss/gss.c)
 endif()
 
 if (MINISAT)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ solvers:
  _tdev_basic _tdev_basic_heuristic minisat_minimal_01 minisat_natural_01 minisat_complete_01 
  minisat_augmented_01 _tdev_dpll_triad _tdev_dpll_triad_scc_i _tdev_dpll_triad_scc_h 
  _tdev_dpll_triad_scc_ih norvig fast_solv_9r2 kudoku bb_sudoku jsolve fsss2 fsss2_locked jczsolve 
- sk_bforce2 rust_sudoku tdoku
+ sk_bforce2 rust_sudoku tdoku gss gss[1-8]
 build info: Clang 8.0.1 -O3 -march=native
 </pre>
 

--- a/other/README.md
+++ b/other/README.md
@@ -33,6 +33,13 @@ configured here.
  -- An early exact cover solver (but not DLX).\
  -- build with -DKUDOKU=on
 
+1. **gss** (Bart 2019)\
+    (from [here](https://github.com/bartp5/gss)).\
+ -- To the location of your choice clone https://github.com/bartp5/gss.\
+ -- Link required files using:\
+    `$ other/gss/link.sh path/to/gss`\
+ -- build with -DGSS=on
+ 
 1. **FSSS2** (M.Dobrichev 2014-2015)\
  -- To the location of your choice clone https://github.com/t-dillon/fsss2_bench (a fork of
     dobrichev/fsss2 with some patches to work with the benchmark program here).\

--- a/other/gss/gss.c
+++ b/other/gss/gss.c
@@ -1,0 +1,107 @@
+/*
+    Generic Sudoku Solver (gss) link to tdoku benchmark
+    Copyright (C) 2019 B. Pieters
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include "sudoku.h"
+#include "sudoku_parser.h"
+static int init=0;
+static Sudoku S;
+static int STRAT=0;
+int gss_verbose=0;
+int S_ReadCompactStandard(const char *s, Sudoku *S)
+{
+	int i, k;
+	char c;
+	k=0;		
+	while ((*s)&&(k<81))
+	{
+		c=*s;
+		s++;
+		if ((c=='0')||(c=='.'))
+		{
+			S->M[k]=0;
+			for (i=0;i<S->BS;i++)
+				S->M[k]|=VX[i];
+			k++;
+		}
+		else if (isdigit(c))
+		{
+			S->M[k]=VX[(int)(c-'1')];
+			k++;
+		}	
+	}
+	if (k!=81)
+		return 0;
+	if (Check(S))
+		return 0;
+	return 1;
+}
+
+size_t OtherSolverGss(const char *input, size_t limit /* unused */,
+                         uint32_t configuration /* unused */,
+                         char *solution, size_t *num_guesses) 
+{
+	int limitlevel;
+	int maxlevel;
+	int ns;
+	int i;
+	MASKINT **sol;
+	SSTATE state;
+	if (!init)
+	{
+		S_init();
+		S=S_InitStdSudoku(1);
+		/* load all logic */
+		STRAT|=(1<<MASK);
+		STRAT|=(1<<MASKHIDDEN);
+		STRAT|=(1<<MASKINTER);
+		STRAT|=(1<<BRUTE);			
+		init=1;
+	}
+		
+		
+	limitlevel=(int)configuration;
+	if (!S_ReadCompactStandard(input, &S))
+		return 0;
+		
+	sol=malloc(sizeof(MASKINT *));
+	state=Solve(&S, &maxlevel, &sol, &ns, 2, limitlevel, STRAT);
+	solution[81]='\0';
+	switch(state)
+	{
+		case SOLVED:
+			for (i=0;i<81;i++)
+				solution[i]='0'+(char)EL_V(S.M[i], S.BS);
+			free(sol);		
+			return 1;
+		case MULTISOL:
+			for (i=0;i<81;i++)
+				solution[i]='0'+(char)EL_V(sol[0][i], S.BS);
+			for (i=0;i<ns;i++)
+				free(sol[i]);
+			free(sol);		
+			return (size_t)ns;
+		case INVALID:
+		case UNSOLVED:
+		default:
+			return 0;
+	}
+}
+

--- a/other/gss/gss.c
+++ b/other/gss/gss.c
@@ -1,19 +1,31 @@
 /*
     Generic Sudoku Solver (gss) link to tdoku benchmark
     Copyright (C) 2019 B. Pieters
+	BSD 2-Clause License
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	Copyright (c) 2019, Tom Dillon
+	All rights reserved.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	1. Redistributions of source code must retain the above copyright notice, this
+	   list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice,
+	   this list of conditions and the following disclaimer in the documentation
+	   and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+	AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+	FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+	DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+	CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+	OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <stdlib.h>
 #include <stdio.h>
@@ -54,11 +66,8 @@ int S_ReadCompactStandard(const char *s, Sudoku *S)
 	return 1;
 }
 
-size_t OtherSolverGss(const char *input, size_t limit /* unused */,
-                         uint32_t configuration /* unused */,
-                         char *solution, size_t *num_guesses) 
+size_t OtherSolverGss(const char *input, size_t limit, uint32_t configuration, char *solution, size_t *num_guesses) 
 {
-	int limitlevel;
 	int maxlevel;
 	int ns;
 	int i;
@@ -76,13 +85,11 @@ size_t OtherSolverGss(const char *input, size_t limit /* unused */,
 		init=1;
 	}
 		
-		
-	limitlevel=(int)configuration;
 	if (!S_ReadCompactStandard(input, &S))
 		return 0;
 		
 	sol=malloc(sizeof(MASKINT *));
-	state=Solve(&S, &maxlevel, &sol, &ns, 2, limitlevel, STRAT);
+	state=Solve(&S, &maxlevel, &sol, &ns, (int)limit, (int)configuration, STRAT);
 	solution[81]='\0';
 	switch(state)
 	{

--- a/other/gss/gss.c
+++ b/other/gss/gss.c
@@ -106,8 +106,9 @@ size_t OtherSolverGss(const char *input, size_t limit, uint32_t configuration, c
 			free(sol);		
 			return (size_t)ns;
 		case INVALID:
-		case UNSOLVED:
+		case UNSOLVED:	
 		default:
+			free(sol);
 			return 0;
 	}
 }

--- a/other/gss/link.sh
+++ b/other/gss/link.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+[ -d "$1" ] || (echo "gss directory '$1' does not exist" ; exit 1)
+
+gss=$(cd $1; pwd)
+cd $(dirname "${BASH_SOURCE[0]}")
+
+for f in sudoku.c \
+         sudoku.h \
+         sudoku_parser.c \
+         sudokusolver.h \
+         sudoku_parser.h
+do
+    ln -s ${gss}/${f}
+done
+
+

--- a/src/all_solvers.h
+++ b/src/all_solvers.h
@@ -55,6 +55,7 @@ extern "C" {
     SolverFn OtherSolverNorvig;
     SolverFn OtherSolverJSolve;
     SolverFn OtherSolverKudoku;
+    SolverFn OtherSolverGss;
     SolverFn OtherSolverFsss2;
     SolverFn OtherSolverJCZSolve;
     SolverFn OtherSolverSKBFORCE2;
@@ -135,6 +136,17 @@ std::vector<Solver> GetAllSolvers() {
 #endif
 #ifdef KUDOKU
     solvers.emplace_back(Solver(OtherSolverKudoku,            0, "kudoku",                    7));
+#endif
+#ifdef GSS
+    solvers.emplace_back(Solver(OtherSolverGss,               1, "gss1",                      7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  2, "gss2",         			  7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  3, "gss3",         			  7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  4, "gss4",         			  7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  5, "gss5",         			  7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  6, "gss6",         			  7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  7, "gss7",         			  7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  8, "gss8",         			  7));
+    solvers.emplace_back(Solver(OtherSolverGss,      		  0, "gss",         			  7));
 #endif
 #ifdef BB_SUDOKU
     solvers.emplace_back(Solver(OtherSolverBBSudoku,          0, "bb_sudoku",                15));


### PR DESCRIPTION
Hi,
Thanks for the great sudoku solver and benchmark tool. 
I created the gss solver (https://github.com/bartp5/gss). I never intended to build such an optimized solver but rather created a solver for many types of sudokus (i.e. jigsaw, X, various sizes, etc.). Just out of curiosity I wanted to see how my solver compares. My solver implements "levels" of logic and uses backtracking when nothing else works, so I used the "configuration" argument to benchmark the various levels of logic.
Cheers,
Bart